### PR TITLE
update build.sh to use depends and add libsodium

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,29 +2,13 @@
 # EMC2 build script for Ubuntu & Debian 9 v.3 (c) Decker (and webworker)
 # modified for CHIPS by Duke Leto
 
-berkeleydb () {
     CHIPS_ROOT=$(pwd)
-    CHIPS_PREFIX="${CHIPS_ROOT}/db4"
-    mkdir -p $CHIPS_PREFIX
-    wget -N 'http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
-    echo '12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef db-4.8.30.NC.tar.gz' | sha256sum -c
-    tar -xzvf db-4.8.30.NC.tar.gz
-    cd db-4.8.30.NC/build_unix/
-
-    ../dist/configure -enable-cxx -disable-shared -with-pic -prefix=$CHIPS_PREFIX
-
-    make install
-    cd $CHIPS_ROOT
-}
-
-buildchips () {
     git pull
     make clean
+    cd depends
+    make NO_QT=1
+    cd ..
     ./autogen.sh
-    ./configure LDFLAGS="-L${CHIPS_PREFIX}/lib/" CPPFLAGS="-I${CHIPS_PREFIX}/include/" --with-gui=no --disable-tests --disable-bench --without-miniupnpc --enable-experimental-asm --enable-static --disable-shared
-    make -j$(nproc)
-}
+CONFIG_SITE="$PWD/depends/x86_64-pc-linux-gnu/share/config.site"    ./configure LDFLAGS="-L${CHIPS_ROOT}/depends/x86_64-pc-linux-gnu/lib" CPPFLAGS="-I${CHIPS_ROOT}/depends/x86_64-pc-linux-gnu//include" --with-gui=no --disable-tests --disable-bench --without-miniupnpc --enable-experimental-asm --enable-static --disable-shared --with-boost-libdir=$(pwd)/depends/x86_64-pc-linux-gnu/lib 
+    make #  -j$(nproc)
 
-berkeleydb
-buildchips
-echo "Done building CHIPS!"

--- a/depends/packages/libsodium.mk
+++ b/depends/packages/libsodium.mk
@@ -1,0 +1,23 @@
+package=libsodium
+$(package)_version=1.0.15
+$(package)_download_path=https://download.libsodium.org/libsodium/releases/old/
+$(package)_file_name=$(package)-$($(package)_version).tar.gz
+$(package)_sha256_hash=fb6a9e879a2f674592e4328c5d9f79f082405ee4bb05cb6e679b90afe9e178f4
+$(package)_dependencies=
+$(package)_config_opts=
+
+define $(package)_preprocess_cmds
+  cd $($(package)_build_subdir); ./autogen.sh
+endef
+
+define $(package)_config_cmds
+  $($(package)_autoconf) --enable-static --disable-shared
+endef
+
+define $(package)_build_cmds
+  $(MAKE)
+endef
+
+define $(package)_stage_cmds
+  $(MAKE) DESTDIR=$($(package)_staging_dir) install
+endef

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -1,4 +1,4 @@
-packages:=boost openssl libevent zeromq
+packages:=boost openssl libevent zeromq libsodium
 
 qt_native_packages = native_protobuf
 qt_packages = qrencode protobuf zlib


### PR DESCRIPTION
redoes build.sh to use depends and adds libsodium to depends; uses depends for bdb 4.8 and boost